### PR TITLE
Ensure manifest-*.txt has data/ prefix

### DIFF
--- a/src/components/CrateCreator/CrateExport/bagit.js
+++ b/src/components/CrateCreator/CrateExport/bagit.js
@@ -26,7 +26,7 @@ export default class Bag {
 
         let manifest = "";
         for (let item of items) {
-            manifest += `${item.hash} ${item.file}\n`;
+            manifest += `${item.hash} data/${item.file}\n`;
         }
         await fs.writeFile(manifestPath, manifest);
 


### PR DESCRIPTION
The [payload manifest](https://www.rfc-editor.org/rfc/rfc8493.html#section-2.1.3) should use _pathname of a file relative to the base directory_

See [example in RFC8493](https://www.rfc-editor.org/rfc/rfc8493.html#section-4.1)